### PR TITLE
Prevent bad ban expiry format from breaking render, make examples more explicit

### DIFF
--- a/infobat/http.py
+++ b/infobat/http.py
@@ -129,7 +129,18 @@ class InfobatWebUI(object):
             if raw_expire_at == 'never':
                 expire_at = None
             else:
-                expire_at = parse_time_string(raw_expire_at)
+                try:
+                    expire_at = parse_time_string(raw_expire_at)
+                except ValueError:
+                    # This will cause the ban reason in the form to be the old
+                    # one (from the DB), not very user-friendly... but it
+                    # prevents the exception from breaking the page.
+                    message = (
+                        'Invalid expiration timestamp or relative date {0!r}'
+                    ).format(raw_expire_at)
+                    renderTemplate(request, self.loader.load('edit_ban.html'),
+                        ban=ban, message=message)
+                    return
         if 'reason' in request.args:
             reason = request.args['reason'][0]
         yield self.dbpool.update_ban_by_rowid(rowid, expire_at, reason)

--- a/infobat/templates/edit_ban.html
+++ b/infobat/templates/edit_ban.html
@@ -18,9 +18,13 @@
   <h3>Help for relative dates</h3>
   <p>
     If an expiration date starts with +, the date will be parsed as a date
-    relative to right now. Examples include <tt>+1month</tt>, <tt>+1year
-    6month</tt>, and <tt>+1year 1month 1week 1day 1hour 1minute 1second</tt>.
+    relative to right now. Examples include:
   </p>
+  <ul>
+    <li><tt>+1month</tt></li>
+    <li><tt>+1year 6month</tt></li>
+    <li><tt>+1year 1month 1week 1day 1hour 1minute 1second</tt></li>
+  </ul>
   </py:match>
   <xi:include href="base.html" />
 </html>


### PR DESCRIPTION
Fix #3 by trapping ValueError from `util.parse_time_string` and rendering the template with an error message.

While this prevents the template from being rendered with the an updated ban reason, it should do as an interim fix until the form handling is improved.
