### PR TITLE
Fix http.get_page

### DIFF
--- a/infobat/http.py
+++ b/infobat/http.py
@@ -22,10 +22,50 @@ class MarginallyImprovedHTTPClientFactory(client.HTTPClientFactory):
             self.deferred.callback((page, self))
 
 def get_page(url, *a, **kw):
-    scheme, host, port, path = client._parse(url)
+    scheme, host, port, path = _parse(url)
     factory = MarginallyImprovedHTTPClientFactory(url, *a, **kw)
     reactor.connectTCP(host, port, factory)
     return factory.deferred
+
+# TODO: Replace this hack with something supportable.
+from urlparse import urlunparse
+from twisted.web.http import urlparse
+# Borrowed from Twisted 13.0.0
+def _parse(url, defaultPort=None):
+    """
+    Split the given URL into the scheme, host, port, and path.
+    @type url: C{str}
+    @param url: An URL to parse.
+    @type defaultPort: C{int} or C{None}
+    @param defaultPort: An alternate value to use as the port if the URL does
+    not include one.
+    @return: A four-tuple of the scheme, host, port, and path of the URL.  All
+    of these are C{str} instances except for port, which is an C{int}.
+    """
+    url = url.strip()
+    parsed = urlparse(url)
+    scheme = parsed[0]
+    path = urlunparse(('', '') + parsed[2:])
+
+    if defaultPort is None:
+        if scheme == 'https':
+            defaultPort = 443
+        else:
+            defaultPort = 80
+
+    host, port = parsed[1], defaultPort
+    if ':' in host:
+        host, port = host.split(':')
+        try:
+            port = int(port)
+        except ValueError:
+            port = defaultPort
+
+    if path == '':
+        path = '/'
+
+    return scheme, host, port, path
+
 
 def renderTemplate(request, tmpl, **kwargs):
     request.setHeader('Content-type', 'text/html; charset=utf-8')


### PR DESCRIPTION
`infobat.http.get_page` uses a no-longer-extant private function from twisted for parsing URLs, breaking repaste and other things the depend on it.

This change just copies the old private function from twisted 13 so get_page works again.