### PR TITLE
Deglobalize config by passing it around directly

### DIFF
--- a/infobat/config.py
+++ b/infobat/config.py
@@ -50,7 +50,7 @@ class Channel(object):
         return self._conf.translate(message, lang=self.lang,
             encoding=self.encoding)
 
-class _Config(object):
+class InfobatConfig(object):
     def __init__(self):
         self.config = {}
         self.channels = {}
@@ -122,7 +122,4 @@ class _Config(object):
         return t.ugettext(message).encode(encoding)
 
     def __repr__(self):
-        return '_Config(%r)' % (self.config,)
-
-# global config object
-conf = _Config()
+        return 'InfobatConfig(%r)' % (self.config,)

--- a/infobat/database.py
+++ b/infobat/database.py
@@ -1,5 +1,4 @@
 from twisted.enterprise import adbapi
-from infobat.config import conf
 from functools import partial
 import dateutil.tz
 import datetime
@@ -38,9 +37,10 @@ _ADD_HOST_TO_USER = """
 """
 
 class InfobatDatabaseRunner(object):
-    def __init__(self):
+    def __init__(self, conf):
+        self._conf = conf
         self.dbpool = adbapi.ConnectionPool(
-            'sqlite3', conf['database.sqlite.db_file'],
+            'sqlite3', self._conf['database.sqlite.db_file'],
             check_same_thread=False,
             cp_openfun=self._setup_connection,
             detect_types=sqlite3.PARSE_COLNAMES)
@@ -175,7 +175,7 @@ class InfobatDatabaseRunner(object):
             )
         """)
         txn.executemany("INSERT INTO unsure_bans VALUES (?, ?, ?)", bans)
-        expire_at = time.time() + conf.channel(channel).default_ban_time
+        expire_at = time.time() + self._conf.channel(channel).default_ban_time
         reason = time.strftime("ban pulled from banlist on %F")
         txn.execute("""
             INSERT INTO bans
@@ -207,7 +207,7 @@ class InfobatDatabaseRunner(object):
     @interaction
     def add_ban(self, txn, channel, host, mask, mode):
         now = time.time()
-        expire_at = now + conf.channel(channel).default_ban_time
+        expire_at = now + self._conf.channel(channel).default_ban_time
         txn.execute("""
             INSERT INTO bans
                         (channel, mask, mode, set_at, set_by, expire_at)

--- a/infobat/http.py
+++ b/infobat/http.py
@@ -3,7 +3,6 @@ from twisted.internet import reactor
 from twisted.web import client, server
 from genshi.template import TemplateLoader
 from infobat.database import NoSuchBan
-from infobat.config import conf
 from infobat.util import parse_time_string
 from klein.resource import KleinResource
 from klein.decorators import expose
@@ -91,6 +90,6 @@ class InfobatResource(KleinResource):
         renderTemplate(request, self.loader.load('bans.html'),
             bans=bans, show_unset=False, show_recent_expiration=False)
 
-def makeSite(dbpool):
-    loader = TemplateLoader(conf['web.root'], auto_reload=True)
-    return server.Site(InfobatResource(loader, conf.dbpool))
+def makeSite(templates_dir, dbpool):
+    loader = TemplateLoader(templates_dir, auto_reload=True)
+    return server.Site(InfobatResource(loader, dbpool))

--- a/infobat/irc.py
+++ b/infobat/irc.py
@@ -3,7 +3,6 @@ from twisted.internet import reactor, defer, error, protocol, task
 from twisted.python import log
 from twisted.web import xmlrpc
 from infobat.redent import redent
-from infobat.config import conf
 from infobat import database, http, util
 from datetime import timedelta
 from urllib import urlencode
@@ -69,7 +68,8 @@ class Infobat(irc.IRCClient):
 
     db = dbpool = manhole_service = None
 
-    def __init__(self):
+    def __init__(self, conf):
+        self._conf = conf
         self.nickname = conf['irc.nickname'].encode()
         if conf['irc.password']:
             self.password = conf['irc.password'].encode()
@@ -90,8 +90,8 @@ class Infobat(irc.IRCClient):
         self._quiet_collation = collections.defaultdict(list)
 
     def autojoinChannels(self):
-        for channel in conf['irc.autojoin']:
-            channel_obj = conf.channel(channel)
+        for channel in self._conf['irc.autojoin']:
+            channel_obj = self._conf.channel(channel)
             self.join(channel_obj.name.encode(), channel_obj.key)
 
     def startTimer(self, name, interval, method, *a, **kw):
@@ -109,7 +109,7 @@ class Infobat(irc.IRCClient):
 
     def signedOn(self):
         self.factory.resetDelay()
-        nickserv_pw = conf['irc.nickserv_pw']
+        nickserv_pw = self._conf['irc.nickserv_pw']
         if nickserv_pw:
             self.msg('NickServ', 'identify %s' % nickserv_pw.encode())
         else:
@@ -174,7 +174,7 @@ class Infobat(irc.IRCClient):
         self.sendLine('WHO %s' % (target,))
 
     def joined(self, channel):
-        channel_obj = conf.channel(channel)
+        channel_obj = self._conf.channel(channel)
         if channel_obj.anti_redirect:
             self.part(channel)
             reactor.callLater(5, self.join, channel_obj.anti_redirect.encode())
@@ -327,10 +327,10 @@ class Infobat(irc.IRCClient):
                 return
             log.msg('privmsg from %s: %s' % (user, message))
             target = user
-            channel_obj = conf.channel('privmsg')
+            channel_obj = self._conf.channel('privmsg')
         else:
             target = channel
-            channel_obj = conf.channel(channel)
+            channel_obj = self._conf.channel(channel)
         _ = channel_obj.translate
         if channel_obj.is_usable('lol') and _lol_regex.search(message):
             self.do_lol(user, channel, _)
@@ -374,7 +374,7 @@ class Infobat(irc.IRCClient):
 
     @defer.inlineCallbacks
     def updateBan(self, user, channel, mode_set, mode, mask):
-        channel_obj = conf.channel(channel)
+        channel_obj = self._conf.channel(channel)
         if not channel_obj.have_ops:
             return
         _ = channel_obj.translate
@@ -529,7 +529,9 @@ class Infobat(irc.IRCClient):
                         mask = new_mask
 
         auth = yield self.dbpool.add_ban_auth(rowid)
-        url = urljoin(conf['web.url'], '/bans/edit/%s/%s' % (rowid, auth)).encode()
+        url = urljoin(
+            self._conf['web.url'], '/bans/edit/%s/%s' % (rowid, auth)
+        ).encode()
         self.msg(nick, _(u'to enter and edit details about this ban, please visit %s') % (url,))
 
     def _deopSelf(self):
@@ -540,7 +542,7 @@ class Infobat(irc.IRCClient):
     def _expireBans(self):
         expired = yield self.dbpool.get_expired_bans()
         for channel, it in itertools.groupby(expired, operator.itemgetter(0)):
-            if not conf.channel(channel).have_ops:
+            if not self._conf.channel(channel).have_ops:
                 continue
             yield self.ensureOps(channel)
             for _, mask, mode in it:
@@ -676,7 +678,10 @@ class InfobatFactory(protocol.ReconnectingClientFactory):
     maxDelay = 120
     lastProtocol = None
 
+    def __init__(self, conf):
+        self._conf = conf
+
     def buildProtocol(self, addr):
-        self.lastProtocol = p = self.protocol()
+        self.lastProtocol = p = self.protocol(self._conf)
         p.factory = self
         return p


### PR DESCRIPTION
Fixes #7 

Also tweaked `infobat.http.makeSite` to take in the template dir and db object directly instead of the whole config object.