### PR TITLE
Use API additions.

### DIFF
--- a/infobob/pastebin.py
+++ b/infobob/pastebin.py
@@ -661,8 +661,7 @@ class PinnwandPastebin(object):
         # For now just hardcode, no clue if other pastebins run this.
         self._baseUrl = u'https://bpaste.net'
         self._uploadUrl = self._baseUrl + u'/json/new'
-        self._showUrlPrefix = self._baseUrl + u'/show/'
-        # Valid values are 1day, 1week, and 1month.
+        # Valid values are 1day, 1week
         self._expiry = b'1day'
 
     def checkIfAvailable(self):
@@ -695,4 +694,4 @@ class PinnwandPastebin(object):
             ),
         )
         structure = yield response.json()
-        defer.returnValue(self._showUrlPrefix + structure['paste_id'])
+        defer.returnValue(structure['paste_url'])


### PR DESCRIPTION
Hi, pinnwand (which is what bpaste runs on) has for a while now supported returning the full paste_url. This pull request makes use of that.

Please don't merge yet because while testing this I noted that the wrong protocol is returned (http vs https) :)