### PR TITLE
Tweak docker bits, dependency handling

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -2,7 +2,6 @@
 *
 !README.rst
 !COPYING
-!current-requirements.txt
 !setup.py
 !MANIFEST.in
 !db.schema

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+# Exclude everything, then include just what's necessary.
+*
+!README.rst
+!COPYING
+!current-requirements.txt
+!setup.py
+!MANIFEST.in
+!db.schema
+!infobob.cfg.example
+# `!infobob/**/*.py` would be nicer, but "Exception patterns in .dockerignore
+# do not support wildcard directories" (https://github.com/moby/moby/issues/30018).
+!infobob/*.py
+!infobob/tests/*.py
+!infobob/locale/infobob/*.po
+!infobob/locale/infobob/*.pot
+!infobob/templates/*.html
+!twisted/plugins/*.py

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN adduser --system --group --home /usr/src/app --disabled-login infobob
 
 WORKDIR /usr/src/app
 COPY --from=0 /usr/src/app/wheelhouse wheelhouse
-RUN pip install ./wheelhouse/*
+RUN pip install --no-cache-dir --no-deps --no-index ./wheelhouse/*
 
 COPY infobob.cfg.example db.schema ./
 RUN mkdir -p /app/db

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,8 @@
 FROM pypy:2
 
 WORKDIR /usr/src/app
-COPY current-requirements.txt ./
-RUN pip wheel --no-cache-dir -r current-requirements.txt -w wheelhouse
 COPY . ./src/
-RUN pip wheel --no-cache-dir --no-deps ./src -w wheelhouse
+RUN pip wheel --no-cache-dir ./src -w wheelhouse
 
 FROM pypy:2-slim
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -26,3 +26,8 @@ VOLUME /app
 USER infobob
 ENTRYPOINT ["twistd", "--pidfile=", "-n", "infobob"]
 CMD ["infobob.cfg.example"]
+
+# SOURCE_COMMIT is provided by the Docker Hub build environment.
+ARG SOURCE_COMMIT=<unknown>
+ENV INFOBOB_COMMIT=${SOURCE_COMMIT}
+LABEL infobob_commit=${SOURCE_COMMIT}

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,6 @@
 This is the minimal setup:
 
-1.  Install requirements in a virtualenv.
+1.  Install into a virtualenv (`venv/bin/pip install .`).
 
 2.  Copy infobob.cfg.example to a new file (say, tester.cfg.json) and edit it:
 

--- a/current-requirements.txt
+++ b/current-requirements.txt
@@ -1,6 +1,0 @@
-Genshi==0.7
-lxml==3.6.0
-Pygments==1.4
-python-dateutil==2.5.3
-Twisted[tls]==16.1.1
-klein


### PR DESCRIPTION
- Label docker image with commit hash (in Docker Hub automated builds)

- Add explicit-include dockerignore (to avoid sending ~150 MiB to docker if a virtualenv exists in the dir)

- Tell pip to only install the wheels we give it from the build step (it could have grabbed deps if something odd happened)

- Remove current-requirements.txt

  Deps it had pinned are also all pinned in setup.py, it pinned a different (older) Twisted version, and was even missing some explicit dependencies (treq and attrs). Best to just remove it, we can add a lock file after tests are better.